### PR TITLE
Fix upgrade script mysql compatible

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -25,7 +25,7 @@
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="name" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="The name of the client."/>
-        <FIELD NAME="primarydomain" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="The primary domain of the client."/>
+        <FIELD NAME="primarydomain" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="The primary domain of the client."/>
         <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_scormremote';
-$plugin->release = 2023031301;
-$plugin->version = 2023031301; // Keep in lockstep with version.
+$plugin->release = 2023032900;
+$plugin->version = 2023032900; // Keep in lockstep with version.
 $plugin->requires = 2020061500;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [39, 400];     // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
Change primarydomain field in scormremote_clients table to allow null (Needed when a client has an empty domian list.)
Refactor sql to generic iso - fixes compatibility with mysql
Remove domains form the client domain list that are now primary domains.
