### PR TITLE
Fix upgrade script mysql compatible - (no drop field)

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -25,7 +25,7 @@
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="name" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="The name of the client."/>
-        <FIELD NAME="primarydomain" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="The primary domain of the client."/>
+        <FIELD NAME="primarydomain" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="The primary domain of the client."/>
         <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -190,12 +190,12 @@ function xmldb_scormremote_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2022090201, 'scormremote');
     }
 
-    if ($oldversion < 2023022000) {
+    if ($oldversion < 2023032900) {
 
         $table = new xmldb_table('scormremote_clients');
 
         // Define field primarydomain to be added to scormremote_clients.
-        $field = new xmldb_field('primarydomain', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $field = new xmldb_field('primarydomain', XMLDB_TYPE_CHAR, '255', null, null, null, null);
 
         // Conditionally launch add field primarydomain.
         if (!$dbman->field_exists($table, $field)) {
@@ -211,27 +211,22 @@ function xmldb_scormremote_upgrade($oldversion) {
         }
 
         // Update the primary domain field with the first domain in the
-        $sql = "UPDATE
-                  {scormremote_clients}
-                SET
-                  (primarydomain) = (
-                    SELECT
-                      mscd2.domain
-                    FROM
-                      (
-                        SELECT
-                          mscd1.clientid,
-                          MIN(mscd1.id) firstdomainid
-                        FROM
-                          {scormremote_client_domains} mscd1
-                        GROUP BY
-                          mscd1.clientid
-                      ) AS firstdomains
-                      JOIN {scormremote_client_domains} mscd2 ON firstdomains.firstdomainid = mscd2.id
-                    WHERE
-                      {scormremote_clients}.id = firstdomains.clientid
-                  )
-                ";
+        $sql = "UPDATE {scormremote_clients}
+                   SET primarydomain = (SELECT scd.domain
+                                          FROM {scormremote_client_domains} scd
+                                         WHERE scd.id IN (SELECT MIN(scd1.id) firstdomainid
+                                                            FROM {scormremote_client_domains} scd1
+                                                        GROUP BY scd1.clientid)
+                                         AND scd.clientid = {scormremote_clients}.id)";
+
+        $DB->execute($sql);
+
+        // Remove duplicate domains from the scormremote_client_domains table
+        $sql = "DELETE
+                  FROM {scormremote_client_domains} scd
+                 WHERE scd.domain IN (SELECT sc.primarydomain
+                                        FROM {scormremote_clients} sc
+                                       WHERE sc.id = scd.clientid)";
 
         $DB->execute($sql);
 
@@ -244,7 +239,7 @@ function xmldb_scormremote_upgrade($oldversion) {
         $dbman->add_index($table, $index);
 
         // Scormremote savepoint reached.
-        upgrade_mod_savepoint(true, 2023022000, 'scormremote');
+        upgrade_mod_savepoint(true, 2023032900, 'scormremote');
     }
 
         return true;

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_scormremote';
-$plugin->release = 2023031301;
-$plugin->version = 2023031301; // Keep in lockstep with version.
+$plugin->release = 2023032900;
+$plugin->version = 2023032900; // Keep in lockstep with version.
 $plugin->requires = 2020061500;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [39, 400];     // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
Change primarydomain field in scormremote_clients table to allow null (Needed when a client has an empty domian list.)
Refactor sql to generic iso - fixes compatibility with mysql
Remove domains form the client domain list that are now primary domains.