### PR TITLE
53 Fix redirect on Subscription limit reached etc

### DIFF
--- a/error.php
+++ b/error.php
@@ -26,8 +26,6 @@
 require(__DIR__.'/../../config.php');
 require_once(__DIR__.'/lib.php');
 
-// No guest autologin.
-require_login(0, false);
 $errorstring = optional_param('error', null, PARAM_RAW_TRIMMED);
 $PAGE->set_url('/mod/scormremote/error.php', array('error' => $errorstring));
 $PAGE->set_context(context_system::instance());


### PR DESCRIPTION
Previously error statuses (for example, 402 | Subscription limit reached) showed instead the Moodle login page as the browser was redirected to this.  This change removes the require_login() so the expected error message is shown.

Proposed fix for #53.