### PR TITLE
Fix security issue: Check user CM visibility

### DIFF
--- a/lang/en/scormremote.php
+++ b/lang/en/scormremote.php
@@ -87,6 +87,7 @@ $string['error_imsmanifestmissing'] = 'The imsmanifest.xml is missing from the f
 $string['event_error_name'] = 'SCORM Remote error';
 $string['event_seatallocated_name'] = 'SCORM Remote seat allocated';
 $string['event_remoteviewed_name'] = 'SCORM Remote viewed';
+$string['event_missingmanualenrolment'] = 'The user \'{$a->fullname}\' was denied access to a SCORM package with the id \'{$a->cmid}\' as it is not currently visible to them.';
 $string['event_nosubscription'] = 'The user \'{$a->fullname}\' was denied access to a SCORM package for the course with id \'{$a->courseid}\' as the client \'{$a->clientname}\' does not have a subscription that includes this package.';
 $string['event_seatlimitreached'] = 'The user \'{$a->fullname}\' was denied access to a SCORM package for the course with id \'{$a->courseid}\' as the client \'{$a->clientname}\' ({$a->origin}) has reached its seat limit ({$a->seatlimit}).';
 $string['event_scormviewed'] = 'The user \'{$a->fullname}\' viewed a SCORM package for the course with id \'{$a->courseid}\' from client \'{$a->clientname}\'.';

--- a/lib.php
+++ b/lib.php
@@ -269,6 +269,23 @@ function scormremote_pluginfile($course, $cm, $context, $filearea, $args, $force
             $enrolplugin->enrol_user($instance, $user->id, $roleid);
         }
 
+        $course_modinfo = get_fast_modinfo($course->id);
+        if (empty($course_modinfo->get_cms()[$cm->id]) || !$course_modinfo->get_cm($cm->id)->get_user_visible()) {
+            \mod_scormremote\event\remote_view_error::create([
+                'context' => $context,
+                'courseid' => $course->id,
+                'relateduserid' => $user->id,
+                'other' => [
+                    'reason' => get_string('event_missingmanualenrolment', 'mod_scormremote', [
+                        'cmid'     => $cm->id,
+                        'fullname' => $fullname,
+                    ]),
+                ]
+            ])->trigger();
+            $errorurl = $CFG->wwwroot . '/mod/scormremote/error.php?error=unauthorized';
+            exit($OUTPUT->render_from_template('mod_scormremote/init', ['datasource' => $errorurl]));
+        }
+
         // Log last access.
         $original = $USER;
         $USER = $user;


### PR DESCRIPTION
Currently the plugin will still load data where the activity or course are hidden or pending deletion.