### PR TITLE
Fix missing param

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -323,10 +323,16 @@ function scormremote_pluginfile($course, $cm, $context, $filearea, $args, $force
             '/',
             'layer3.js'
         );
+        $jssource->params([
+            'lms_origin' => $origin,
+            'student_id' => $username,
+            'student_name' => $fullname,
+            'client_id' => $clientid,
+        ]);
 
         $templatedata = [
             'datasource'       => $datasource,
-            'jssource'         => $jssource . "?lms_origin={$origin}&student_id={$username}&student_name={$fullname}",
+            'jssource'         => $jssource->out(false),
             'scormagainsource' => $CFG->wwwroot . '/mod/scormremote/scorm-again/scorm12.js',
         ];
         exit($OUTPUT->render_from_template('mod_scormremote/thirdlayer', $templatedata));

--- a/templates/thirdlayer.mustache
+++ b/templates/thirdlayer.mustache
@@ -45,7 +45,7 @@
   <title>Layer 3</title>
   <meta charset="UTF-8" />
   <script src="{{scormagainsource}}"></script>
-  <script src="{{jssource}}"></script>
+  <script src="{{{jssource}}}"></script>
   <style>
     html,
     body,


### PR DESCRIPTION
The client ID is not set on the URL passed to the third layer template, this means that if you have non-unique customer domains it fails.