### PR TITLE
Fix undefined client_id in old wrappers

### DIFF
--- a/amd/src/layer2.js
+++ b/amd/src/layer2.js
@@ -71,7 +71,7 @@ function init() {
     datasource.search += 'lms_origin=' + document.location.host;
     datasource.search += '&student_id=' + (CMI.core ? CMI.core.student_id : '');
     datasource.search += '&student_name=' + (CMI.core ? CMI.core.student_name : '');
-    datasource.search += '&client_id=' + document.body.dataset.clientid;
+    datasource.search += '&client_id=' + ('clientid' in document.body.dataset ? document.body.dataset.clientid : '');
     ORIGIN = datasource.origin;
 
     // Add event listener.

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_scormremote';
-$plugin->release = 2024110100;
-$plugin->version = 2024110100; // Keep in lockstep with version.
+$plugin->release = 2024110400;
+$plugin->version = 2024110400; // Keep in lockstep with version.
 $plugin->requires = 2020061500;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [39, 404];     // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
Occurs with wrappers generated with a scormremote version older than 2023031301