### PR TITLE
Add fallback for when cmi.core._children is missing

### DIFF
--- a/amd/src/layer2.js
+++ b/amd/src/layer2.js
@@ -63,6 +63,20 @@ const ALLOWED_TO_LMSGETVALUE = [
     'cmi.interactions.*.correct_responses._count',
 ];
 
+const CMI_CORE_FALLBACK = [
+    'student_id',
+    'student_name',
+    'lesson_location',
+    'credit',
+    'lesson_status',
+    'entry',
+    'score',
+    'total_time',
+    'lesson_mode',
+    'exit',
+    'session_time',
+];
+
 /**
  * Initialize communication with the LMS
  *
@@ -565,7 +579,11 @@ function LMSGetChildren(parent, children) {
  */
 function LMSGetSupportedChildren(name) {
     const result = LMSGetValue(name + '._children');
-    if (result === "") {
+    if (result === "" && name === "cmi.core") {
+        // Add a fallback in case cmi.core._children isn't specified.
+        message(levels.ERROR, 'LMS has not implemented cmi.core._children, checking all cmi.core');
+        return CMI_CORE_FALLBACK;
+    } else if (result === "") {
         return false;
     }
     return result.split(',');

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_scormremote';
-$plugin->release = 2024110600;
-$plugin->version = 2024110600; // Keep in lockstep with version.
+$plugin->release = 2025041000;
+$plugin->version = 2025041000; // Keep in lockstep with version.
 $plugin->requires = 2020061500;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [39, 404];     // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
We've ran into an issue of scorms being inaccessible on a certain LMS because cmi.core._children was not implemented even though the child methods were. 

This adds a fallback - though still needs to be tested and we have to confirm whether we want the fallback for all or only a select few.